### PR TITLE
Patch to work with macOS 12+

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -30,7 +30,7 @@
 #include <IOKit/usb/USBSpec.h>
 #include "main.h"
 
-#if (MAC_OS_X_VERSION_MAX_ALLOWED < 101700) // Before macOS 12 Monterey
+#if (MAC_OS_X_VERSION_MAX_ALLOWED < 120000) // Before macOS 12 Monterey
 #define kIOMainPortDefault kIOMasterPortDefault
 #endif
 

--- a/src/main.c
+++ b/src/main.c
@@ -30,6 +30,10 @@
 #include <IOKit/usb/USBSpec.h>
 #include "main.h"
 
+#if (MAC_OS_X_VERSION_MAX_ALLOWED < 101700) // Before macOS 12 Monterey
+#define kIOMainPortDefault kIOMasterPortDefault
+#endif
+
 UInt8 disableplugin_value= 0xba;
 
 int main(int argc, char *argv[]) {
@@ -127,7 +131,7 @@ IOUSBDeviceInterface300** usbDeviceInterfaceFromVIDPID(SInt32 vid, SInt32 pid) {
 				      &pid));
 
   /* Getting all the devices that are matched by the matching dictionary */
-  IOServiceGetMatchingServices(kIOMasterPortDefault,
+  IOServiceGetMatchingServices(kIOMainPortDefault,
 			       matchingDict,
 			       &usbRefIterator);
 


### PR DESCRIPTION
`kIOMasterPortDefault` has been renamed to `kIOMainPortDefault`

The pull request changes to fix but also retains the old name for lower macOS version numbers. See the related fix here: https://github.com/kovidgoyal/kitty/issues/3719